### PR TITLE
Add hardening jump guards

### DIFF
--- a/config/features.bzl
+++ b/config/features.bzl
@@ -28,6 +28,20 @@ C_ALL_COMPILE_ACTIONS = [
     ACTION_NAMES.c_compile,
 ]
 
+CPP_COMPILE_NO_ASM_ACTIONS = [
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.lto_backend,
+    ACTION_NAMES.clif_match,
+]
+
+C_COMPILE_NO_ASM_ACTIONS = [
+    ACTION_NAMES.c_compile,
+]
+
 LD_ALL_ACTIONS = [
     ACTION_NAMES.cpp_link_executable,
 ]

--- a/platforms/riscv32/devices.bzl
+++ b/platforms/riscv32/devices.bzl
@@ -8,7 +8,7 @@ DEVICES = [
     device_config(
         name = "opentitan",
         architecture = "rv32imc",
-        feature_set = "//platforms/riscv32/features:rv32imc",
+        feature_set = "//platforms/riscv32/features:rv32imc-hardened",
         constraints = [
             "@platforms//cpu:riscv32",
             "@platforms//os:none",

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -6,6 +6,8 @@ load(
     "//config:features.bzl",
     "CPP_ALL_COMPILE_ACTIONS",
     "C_ALL_COMPILE_ACTIONS",
+    "CPP_COMPILE_NO_ASM_ACTIONS",
+    "C_COMPILE_NO_ASM_ACTIONS",
     "LD_ALL_ACTIONS",
     "feature",
     "feature_set",
@@ -52,6 +54,23 @@ feature(
         ),
     ],
     provides = ["compilation_mode"],
+)
+
+feature(
+    name = "guards",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = C_COMPILE_NO_ASM_ACTIONS + C_COMPILE_NO_ASM_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-mguards",
+                    ],
+                ),
+            ],
+        ),
+    ]
 )
 
 feature(
@@ -111,5 +130,20 @@ feature_set(
         ":all_warnings_as_errors",
         ":fastbuild",
         ":sys_spec",
+    ],
+)
+
+feature_set(
+    name = "rv32imc-hardened",
+    base = [
+        "//features/common",
+        "//features/embedded",
+    ],
+    feature = [
+        ":architecture",
+        ":all_warnings_as_errors",
+        ":fastbuild",
+        ":sys_spec",
+        ":guards",
     ],
 )


### PR DESCRIPTION
This adds support for and enables the use of the compiler hardening for `unimp` guards after jumps.

This patch does not enable the hardening when assembling assembly files, only for the C/C++ compilation/building steps. I also have an alternative patch set that does enable it for assembly files but it requires a new toolchain version and there is still an issue with the infrastructure for publicly updating the toolchains. To avoid being blocked on that any longer, I suggest this approach for now.

To minimize risk, I am making a separate PR for the shadow call stack hardening. I think it is better to enable the two hardenings separately.