### PR TITLE
Update toolchain hardening

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,45 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 180
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      # Update the package index, then install all dependencies listed in
+      # the various apt-requirements.txt files in the project.
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y $(find . -name apt-requirements.txt | xargs sed -e "s/#.*//g")
+      - name: Build
+        run: |
+          bazel build :release
+          bazel run :release -- \
+              --norelease \
+              --noscript \
+              --copy ${PWD}/prebuilt \
+              ${{ inputs.release_tag }}
+      - name: Test
+        run: |
+          cd tests
+          sed -i -e "s/#local_test: //g" WORKSPACE.bazel
+          bazel test //...
+      # The CRT release process renders and commits template files as part
+      # of the release.  We use the github-actions bot as the author of the
+      # commit.  The bot email address is discussed in this thread:
+      # https://github.com/orgs/community/discussions/26560
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          bazel run :release -- ${{ inputs.release_tag }}

--- a/config/features.bzl
+++ b/config/features.bzl
@@ -28,20 +28,6 @@ C_ALL_COMPILE_ACTIONS = [
     ACTION_NAMES.c_compile,
 ]
 
-CPP_COMPILE_NO_ASM_ACTIONS = [
-    ACTION_NAMES.linkstamp_compile,
-    ACTION_NAMES.cpp_compile,
-    ACTION_NAMES.cpp_header_parsing,
-    ACTION_NAMES.cpp_module_compile,
-    ACTION_NAMES.cpp_module_codegen,
-    ACTION_NAMES.lto_backend,
-    ACTION_NAMES.clif_match,
-]
-
-C_COMPILE_NO_ASM_ACTIONS = [
-    ACTION_NAMES.c_compile,
-]
-
 LD_ALL_ACTIONS = [
     ACTION_NAMES.cpp_link_executable,
     ACTION_NAMES.cpp_link_dynamic_library,

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -5,9 +5,7 @@
 load(
     "//config:features.bzl",
     "CPP_ALL_COMPILE_ACTIONS",
-    "CPP_COMPILE_NO_ASM_ACTIONS",
     "C_ALL_COMPILE_ACTIONS",
-    "C_COMPILE_NO_ASM_ACTIONS",
     "LD_ALL_ACTIONS",
     "feature",
     "feature_set",
@@ -58,10 +56,10 @@ feature(
 
 feature(
     name = "guards",
-    enabled = True,
+    enabled = False,
     flag_sets = [
         flag_set(
-            actions = C_COMPILE_NO_ASM_ACTIONS + C_COMPILE_NO_ASM_ACTIONS,
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
             flag_groups = [
                 flag_group(
                     flags = [

--- a/toolchains/lowrisc_rv32imcb/repository.bzl
+++ b/toolchains/lowrisc_rv32imcb/repository.bzl
@@ -8,8 +8,8 @@ def lowrisc_rv32imcb_repos(local = None):
     http_archive_or_local(
         name = "lowrisc_rv32imcb_files",
         local = local,
-        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20221129-1/lowrisc-toolchain-rv32imcb-20221129-1.tar.xz",
-        sha256 = "1258433069e65da8e12fd2d697fc8d1b9d68bfc2dc20f269e58fabb2e30509f0",
-        strip_prefix = "lowrisc-toolchain-rv32imcb-20221129-1",
+        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20230228-1/lowrisc-toolchain-rv32imcb-20230228-1.tar.xz",
+        sha256 = "c28ad597d0a26f03513c4d9feaa6c8c536548112142b355987b6c465d072cc35",
+        strip_prefix = "lowrisc-toolchain-rv32imcb-20230228-1",
         build_file = Label("//toolchains:BUILD.export_all.bazel"),
     )


### PR DESCRIPTION
- Updates the lowRISC toolchain version. In this update, the only difference should be a different implementation of the jump guards hardening. The new implementation no longer applies to assembly files.
- Updates jump guards hardening configuration. It removes the old constructs that were used to make the jump guards hardening only apply to source files. It also disables the jump guards hardening by default, so that we can conditionally enable it in OpenTitan's `.bazelrc` with `build --features=guards` or `--per_file_copt`, etc.